### PR TITLE
Brian Porter - Deposits exercise submission

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,16 +21,27 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
+# Simplify Model validations on date/time fields.
+gem 'validates_timeliness', '~> 7.0.0.beta2'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]
   gem "rspec-rails"
   gem "pry"
   gem "factory_bot_rails"
+  gem 'annotate'
 end
 
 group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+
+ gem 'guard'
+ gem 'guard-rspec', require: false
 end
 
+group :test do
+  gem 'shoulda-matchers', '~> 6.0'
+  gem 'simplecov', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,9 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     base64 (0.2.0)
     bigdecimal (3.1.7)
     bootsnap (1.18.3)
@@ -89,6 +92,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.5.1)
+    docile (1.4.0)
     drb (2.2.1)
     erubi (1.12.0)
     factory_bot (6.4.6)
@@ -96,8 +100,27 @@ GEM
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
+    formatador (1.1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    guard (2.18.1)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.13.0)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -107,9 +130,13 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    lumberjack (1.2.10)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -121,6 +148,7 @@ GEM
     minitest (5.22.3)
     msgpack (1.7.2)
     mutex_m (0.2.0)
+    nenv (0.3.0)
     net-imap (0.4.10)
       date
       net-protocol
@@ -135,8 +163,13 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.3-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.16.3-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.3-x86_64-linux)
       racc (~> 1.4)
+    notiffany (0.1.3)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -183,10 +216,17 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.2.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
     reline (0.5.1)
       io-console (~> 0.5)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.0)
@@ -204,14 +244,28 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.1)
+    shellany (0.0.1)
+    shoulda-matchers (6.2.0)
+      activesupport (>= 5.2.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sqlite3 (1.7.3-aarch64-linux)
     sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-darwin)
     sqlite3 (1.7.3-x86_64-linux)
     stringio (3.1.0)
     thor (1.3.1)
+    timeliness (0.4.5)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    validates_timeliness (7.0.0.beta2)
+      activemodel (>= 7.0.0, < 8)
+      timeliness (>= 0.3.10, < 1)
     webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -222,19 +276,26 @@ PLATFORMS
   aarch64-linux
   arm64-darwin-22
   arm64-darwin-23
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
+  annotate
   bootsnap
   debug
   factory_bot_rails
+  guard
+  guard-rspec
   jbuilder
   pry
   puma (>= 5.0)
   rails (~> 7.1)
   rspec-rails
+  shoulda-matchers (~> 6.0)
+  simplecov
   sqlite3 (~> 1.4)
   tzinfo-data
+  validates_timeliness (~> 7.0.0.beta2)
 
 RUBY VERSION
    ruby 3.3.0p0

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,70 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+## Uncomment and set this to only include directories you want to watch
+# directories %w(app lib config test spec features) \
+#  .select{|d| Dir.exist?(d) ? d : UI.warning("Directory #{d} does not exist")}
+
+## Note: if you are using the `directories` clause above and you are not
+## watching the project directory ('.'), then you will want to move
+## the Guardfile to a watched dir and symlink it back, e.g.
+#
+#  $ mkdir config
+#  $ mv Guardfile config/
+#  $ ln -s config/Guardfile .
+#
+# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+
+# Note: The cmd option is now required due to the increasing number of ways
+#       rspec may be run, below are examples of the most common uses.
+#  * bundler: 'bundle exec rspec'
+#  * bundler binstubs: 'bin/rspec'
+#  * spring: 'bin/rspec' (This will use spring if running and you have
+#                          installed the spring binstubs per the docs)
+#  * zeus: 'zeus rspec' (requires the server to be started separately)
+#  * 'just' rspec: 'rspec'
+
+guard :rspec, cmd: "bundle exec rspec" do
+  require "guard/rspec/dsl"
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # Feel free to open issues for suggestions and improvements
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files)
+
+  # Ruby files
+  ruby = dsl.ruby
+  dsl.watch_spec_files_for(ruby.lib_files)
+
+  # Rails files
+  rails = dsl.rails(view_extensions: %w(erb haml slim))
+  dsl.watch_spec_files_for(rails.app_files)
+  dsl.watch_spec_files_for(rails.views)
+
+  watch(rails.controllers) do |m|
+    [
+      rspec.spec.call("routing/#{m[1]}_routing"),
+      rspec.spec.call("controllers/#{m[1]}_controller"),
+      rspec.spec.call("acceptance/#{m[1]}")
+    ]
+  end
+
+  # Rails config changes
+  watch(rails.spec_helper)     { rspec.spec_dir }
+  watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
+  watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
+
+  # Capybara features specs
+  watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
+  watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
+
+  # Turnip features and steps
+  watch(%r{^spec/acceptance/(.+)\.feature$})
+  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
+    Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,26 @@
 class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
+  rescue_from ActiveRecord::RecordInvalid, with: :validation_failed
 
 
   private
 
   def not_found
-    render json: {error: { msg: 'not found', code: Rack::Utils.status_code(:not_found) } }, status: :not_found
+    render json: {
+      error: {
+        msg: 'not found',
+        code: Rack::Utils.status_code(:not_found)
+      }
+    }, status: :not_found
+  end
+
+  def validation_failed(e)
+    render json: {
+      error: {
+        msg: 'unprocessable entity',
+        code: Rack::Utils.status_code(:unprocessable_entity),
+        details: e.record.errors.messages
+      }
+    }, status: :unprocessable_entity
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,10 @@
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
+
+  private
+
+  def not_found
+    render json: {error: { msg: 'not found', code: Rack::Utils.status_code(:not_found) } }, status: :not_found
+  end
 end

--- a/app/controllers/deposits_controller.rb
+++ b/app/controllers/deposits_controller.rb
@@ -1,0 +1,5 @@
+class DepositsController < ApplicationController
+  def show
+    render json: Deposit.find(params[:id])
+  end
+end

--- a/app/controllers/deposits_controller.rb
+++ b/app/controllers/deposits_controller.rb
@@ -1,5 +1,26 @@
 class DepositsController < ApplicationController
+  # GET /tradelines/:tradeline_id/deposits
+  def index
+    render json: Deposit.where(tradeline: params[:tradeline_id])
+  end
+
+  # GET /deposits/:id
   def show
     render json: Deposit.find(params[:id])
+  end
+
+  # POST /tradelines/:tradeline_id/deposits { deposit: { amount_cents: 0, deposit_date: '2024-06-08' } }
+  def create()
+    tradeline = Tradeline.find(params[:tradeline_id]) # Might raise ActiveRecord::RecordNotFound.
+
+    deposit = Deposit.create!({tradeline:}.merge(deposit_params)) # Might raise ActiveRecord::RecordInvalid
+
+    render json: deposit, head: :created, location: deposit_url(deposit)
+  end
+
+  private
+
+  def deposit_params
+    params.require(:deposit).permit(:amount_cents, :deposit_date)
   end
 end

--- a/app/controllers/tradelines_controller.rb
+++ b/app/controllers/tradelines_controller.rb
@@ -1,17 +1,9 @@
 class TradelinesController < ApplicationController
-  rescue_from ActiveRecord::RecordNotFound, with: :not_found
-
   def index
-    render json: Tradeline.all
+    render json: Tradeline.includes(:deposits).all, methods: :balance_cents, include: :deposits
   end
 
   def show
-    render json: Tradeline.find(params[:id])
-  end
-
-  private
-
-  def not_found
-    render json: 'not_found', status: :not_found
+    render json: Tradeline.includes(:deposits).find(params[:id]), methods: :balance_cents, include: :deposits
   end
 end

--- a/app/models/deposit.rb
+++ b/app/models/deposit.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: deposits
+#
+#  id           :integer          not null, primary key
+#  amount_cents :integer          not null
+#  deposit_date :date             not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  tradeline_id :integer          not null
+#
+# Indexes
+#
+#  index_deposits_on_tradeline_id  (tradeline_id)
+#
+# Foreign Keys
+#
+#  tradeline_id  (tradeline_id => tradelines.id)
+#
+class Deposit < ApplicationRecord
+  # Associations
+  belongs_to :tradeline
+
+  # Validations
+  validates :amount_cents, numericality: { only_integer: true, greater_than: 0 }
+  validates_date :deposit_date
+
+end

--- a/app/models/deposit.rb
+++ b/app/models/deposit.rb
@@ -1,3 +1,13 @@
+class Deposit < ApplicationRecord
+  # Associations
+  belongs_to :tradeline
+
+  # Validations
+  validates :amount_cents, numericality: { only_integer: true, greater_than: 0 }
+  validates_date :deposit_date
+
+end
+
 # == Schema Information
 #
 # Table name: deposits
@@ -17,12 +27,3 @@
 #
 #  tradeline_id  (tradeline_id => tradelines.id)
 #
-class Deposit < ApplicationRecord
-  # Associations
-  belongs_to :tradeline
-
-  # Validations
-  validates :amount_cents, numericality: { only_integer: true, greater_than: 0 }
-  validates_date :deposit_date
-
-end

--- a/app/models/deposit.rb
+++ b/app/models/deposit.rb
@@ -4,7 +4,18 @@ class Deposit < ApplicationRecord
 
   # Validations
   validates :amount_cents, numericality: { only_integer: true, greater_than: 0 }
+  validate :validate_tradeline_balance
   validates_date :deposit_date
+
+  private
+
+  def validate_tradeline_balance
+    return unless tradeline.present?
+
+    if amount_cents > tradeline.balance_cents
+      errors.add :amount_cents, 'Deposit amount exceeds Tradeline balance'
+    end
+  end
 
 end
 

--- a/app/models/tradeline.rb
+++ b/app/models/tradeline.rb
@@ -1,12 +1,27 @@
 class Tradeline < ApplicationRecord
   # Associations
   has_many :deposits, dependent: :destroy
+  has_many :past_deposits, -> { where('deposit_date <= ?', Date.today) }, class_name: 'Deposit'
+
 
   # Virtual fields
 
   # FIXME: Remove this legacy coverage for anything that still uses the decimal value.
   def amount
     (amount_cents / 100.0).round(2)
+  end
+
+  def balance_cents
+    # TODO: Consider caching this value if it gets expensive to compute.
+    deposits_cents = if deposits.size > 0
+      deposits.sum do |d|
+        d.deposit_date <= Date.today ? d.amount_cents : 0
+      end || 0
+    else
+      past_deposits.sum(:amount_cents) || 0
+    end
+
+    amount_cents - deposits_cents
   end
 
 end

--- a/app/models/tradeline.rb
+++ b/app/models/tradeline.rb
@@ -1,2 +1,15 @@
+# == Schema Information
+#
+# Table name: tradelines
+#
+#  id         :integer          not null, primary key
+#  amount     :decimal(8, 2)
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class Tradeline < ApplicationRecord
+  # Associations
+  has_many :deposits, dependent: :destroy
+
 end

--- a/app/models/tradeline.rb
+++ b/app/models/tradeline.rb
@@ -1,15 +1,23 @@
-# == Schema Information
-#
-# Table name: tradelines
-#
-#  id         :integer          not null, primary key
-#  amount     :decimal(8, 2)
-#  name       :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#
 class Tradeline < ApplicationRecord
   # Associations
   has_many :deposits, dependent: :destroy
 
+  # Virtual fields
+
+  # FIXME: Remove this legacy coverage for anything that still uses the decimal value.
+  def amount
+    (amount_cents / 100.0).round(2)
+  end
+
 end
+
+# == Schema Information
+#
+# Table name: tradelines
+#
+#  id           :integer          not null, primary key
+#  amount_cents :integer
+#  name         :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#

--- a/config/initializers/validates_timeliness.rb
+++ b/config/initializers/validates_timeliness.rb
@@ -1,0 +1,40 @@
+ValidatesTimeliness.setup do |config|
+  # Extend ORM/ODMs for full support (:active_record included).
+  config.extend_orms = [ :active_record ]
+  #
+  # Default timezone
+  # config.default_timezone = :utc
+  #
+  # Set the dummy date part for a time type values.
+  # config.dummy_date_for_time_type = [ 2000, 1, 1 ]
+  #
+  # Ignore errors when restriction options are evaluated
+  # config.ignore_restriction_errors = false
+  #
+  # Re-display invalid values in date/time selects
+  # config.enable_date_time_select_extension!
+  #
+  # Handle multiparameter date/time values strictly
+  # config.enable_multiparameter_extension!
+  #
+  # Shorthand date and time symbols for restrictions
+  # config.restriction_shorthand_symbols.update(
+  #   :now   => lambda { Time.current },
+  #   :today => lambda { Date.current }
+  # )
+  #
+  # Use the plugin date/time parser which is stricter and extendable
+  # config.use_plugin_parser = false
+  #
+  # Add one or more formats making them valid. e.g. add_formats(:date, 'd(st|rd|th) of mmm, yyyy')
+  # config.parser.add_formats()
+  #
+  # Remove one or more formats making them invalid. e.g. remove_formats(:date, 'dd/mm/yyy')
+  # config.parser.remove_formats()
+  #
+  # Change the ambiguous year threshold when parsing a 2 digit year
+  # config.parser.ambiguous_year_threshold =  30
+  #
+  # Treat ambiguous dates, such as 01/02/1950, as a Non-US date.
+  # config.parser.remove_us_formats
+end

--- a/config/locales/validates_timeliness.en.yml
+++ b/config/locales/validates_timeliness.en.yml
@@ -1,0 +1,16 @@
+en:
+  errors:
+    messages:
+      invalid_date: "is not a valid date"
+      invalid_time: "is not a valid time"
+      invalid_datetime: "is not a valid datetime"
+      is_at: "must be at %{restriction}"
+      before: "must be before %{restriction}"
+      on_or_before: "must be on or before %{restriction}"
+      after: "must be after %{restriction}"
+      on_or_after: "must be on or after %{restriction}"
+  validates_timeliness:
+    error_value_formats:
+      date: '%Y-%m-%d'
+      time: '%H:%M:%S'
+      datetime: '%Y-%m-%d %H:%M:%S'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   resources :tradelines
+  resources :deposits, only: [:show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  resources :tradelines
+  resources :tradelines do
+    resources :deposits, only: [:index, :create]
+  end
   resources :deposits, only: [:show]
 end

--- a/db/migrate/20240608183442_create_deposits.rb
+++ b/db/migrate/20240608183442_create_deposits.rb
@@ -1,0 +1,11 @@
+class CreateDeposits < ActiveRecord::Migration[7.1]
+  def change
+    create_table :deposits do |t|
+      t.references :tradeline, null: false, foreign_key: true
+      t.integer :amount_cents, null: false
+      t.date :deposit_date, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240608212631_add_amount_cents_to_tradelines.rb
+++ b/db/migrate/20240608212631_add_amount_cents_to_tradelines.rb
@@ -1,0 +1,11 @@
+class AddAmountCentsToTradelines < ActiveRecord::Migration[7.1]
+  def up
+    add_column :tradelines, :amount_cents, :integer, null: false
+
+    Tradeline.update_all('amount_cents = ROUND(amount * 100, 0)')
+  end
+
+  def down
+    remove_column :tradelines, :amount_cents
+  end
+end

--- a/db/migrate/20240608222924_remove_amount_from_tradelines.rb
+++ b/db/migrate/20240608222924_remove_amount_from_tradelines.rb
@@ -1,0 +1,12 @@
+class RemoveAmountFromTradelines < ActiveRecord::Migration[7.1]
+  def up
+    remove_column :tradelines, :amount
+  end
+
+  def down
+    add_column :tradelines, :amount, :decimal, precision: 8, scale: 2
+
+    # Possible loss of precision here.
+    Tradeline.update_all('amount = ROUND(amount_cents / 100, 2)')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_13_043029) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_08_183442) do
+  create_table "deposits", force: :cascade do |t|
+    t.integer "tradeline_id", null: false
+    t.integer "amount_cents", null: false
+    t.date "deposit_date", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tradeline_id"], name: "index_deposits_on_tradeline_id"
+  end
+
   create_table "tradelines", force: :cascade do |t|
     t.string "name", null: false
     t.decimal "amount", precision: 8, scale: 2
@@ -18,4 +27,5 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_13_043029) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "deposits", "tradelines"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_08_183442) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_08_222924) do
   create_table "deposits", force: :cascade do |t|
     t.integer "tradeline_id", null: false
     t.integer "amount_cents", null: false
@@ -22,9 +22,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_08_183442) do
 
   create_table "tradelines", force: :cascade do |t|
     t.string "name", null: false
-    t.decimal "amount", precision: 8, scale: 2
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "amount_cents"
   end
 
   add_foreign_key "deposits", "tradelines"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,29 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+# Load any CSV files in `db/seeds/`. Can be organized using numeric
+# prefixes like `01_parent.csv`, `02_child.csv` to ensure association
+# integrity. CSV files are processed by ERB during load to allow for
+# dynamic values.
+
+return unless Rails.env.development?
+
+require 'csv'
+require 'erb'
+
+Dir.glob(Rails.root.join('db', 'seeds', '*.csv')).sort.each do |csv_file|
+  model = File.basename(csv_file, ".csv").slice(/\d+_(.*)/, 1).classify.constantize
+
+  puts "Seeding '#{csv_file.sub(Rails.root.to_s, '')}' into model '#{model}'..."
+
+  processed_csv = ERB.new(File.read(csv_file)).result
+
+  CSV.parse(processed_csv, headers: true, skip_blanks: true).each do |row|
+    record = model.find_or_create_by(row.to_hash)
+    puts record.valid? ? record : record.errors.to_a
+  end
+
+  puts 'Done.'
+end
+

--- a/db/seeds/010_tradelines.csv
+++ b/db/seeds/010_tradelines.csv
@@ -1,0 +1,4 @@
+id,name,amount
+1,First Tradeline,123.45
+2,Zero Balance,0.0
+3,Fully Paid Deposits Next Month,100.0

--- a/db/seeds/020_deposits.csv
+++ b/db/seeds/020_deposits.csv
@@ -1,0 +1,5 @@
+id,tradeline_id,amount_cents,deposit_date
+1,1,6780,<%= 2.days.ago.to_date.to_s %>
+2,3,5000,<%= 3.weeks.ago.to_date.to_s %>
+3,3,4000,<%= 4.weeks.ago.to_date.to_s %>
+4,3,1000,<%= 1.month.from_now.to_date.to_s %>

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'after',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'true',
+      'exclude_fixtures'            => 'true',
+      'exclude_factories'           => 'true',
+      'exclude_serializers'         => 'true',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/controllers/deposits_controller_spec.rb
+++ b/spec/controllers/deposits_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe DepositsController, type: :controller do
+  describe '#show' do
+    let(:deposit) { FactoryBot.create :deposit }
+
+    it 'responds with a 200' do
+      get :show, params: { id: deposit.id }
+      expect(response).to have_http_status(:ok)
+    end
+
+    context 'if the deposit is not found' do
+      it 'responds with a 404' do
+        get :show, params: { id: 0 }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/controllers/deposits_controller_spec.rb
+++ b/spec/controllers/deposits_controller_spec.rb
@@ -1,8 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe DepositsController, type: :controller do
+  describe '#index' do
+    let(:tradeline) do
+      create(:tradeline_with_deposits,
+        amount_cents: 100_00,
+        deposits_cents: [25_00, 15_00, 30_00],
+      )
+    end
+
+    it 'responds with a 200' do
+      get :index, params: { tradeline_id: tradeline.id }
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+
+      returned_ids = json.pluck('id')
+      expect(returned_ids).to eq(tradeline.deposits.pluck(:id))
+    end
+  end
+
   describe '#show' do
-    let(:deposit) { FactoryBot.create :deposit }
+    let(:deposit) { create(:deposit, amount_cents: 1_00) }
 
     it 'responds with a 200' do
       get :show, params: { id: deposit.id }
@@ -12,6 +31,53 @@ RSpec.describe DepositsController, type: :controller do
     context 'if the deposit is not found' do
       it 'responds with a 404' do
         get :show, params: { id: 0 }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe '#create' do
+    let(:tradeline) { create(:tradeline, amount_cents: 500_00) }
+    let(:json) { JSON.parse(response.body) }
+    before do
+      post(:create,
+        params: {
+          tradeline_id: tradeline.id,
+          deposit: {
+            amount_cents: deposit_amount,
+            deposit_date: '2024-06-09',
+          },
+        },
+        as: :json
+      )
+    end
+
+    context 'success' do
+      let(:deposit_amount) { 100_00 }
+
+      it 'accepts a deposit below Tradeline balance' do
+        expect(response).to have_http_status(:ok)
+        expect(json).to include(
+          'amount_cents' => deposit_amount,
+          'tradeline_id' => tradeline.id,
+        )
+      end
+    end
+
+    context 'validation failures' do
+      let(:deposit_amount) { 800_00 }
+
+      it 'rejects a deposit above Tradeline balance' do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json['error']['details']['amount_cents']).to include(/Deposit amount exceeds Tradeline balance/)
+      end
+    end
+
+    context 'tradeline not found' do
+      let(:deposit_amount) { 9_00 }
+      let(:tradeline) { build(:tradeline, id: -1) }
+
+      it 'rejects a deposit for a non-existent Tradeline' do
         expect(response).to have_http_status(:not_found)
       end
     end

--- a/spec/controllers/tradelines_controller_spec.rb
+++ b/spec/controllers/tradelines_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe TradelinesController, type: :controller do
   end
 
   describe '#show' do
-    let(:tradeline) { FactoryBot.create :tradeline }
+    let(:tradeline) { create(:tradeline) }
 
     it 'responds with a 200' do
       get :show, params: { id: tradeline.id }

--- a/spec/factories/deposit.rb
+++ b/spec/factories/deposit.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :deposit do
+    association :tradeline, amount_cents: 1000_00
+    deposit_date { Date.yesterday.to_s } # Intentionally use a string instead of Date object.
+    amount_cents { 55_43 }
+
+    trait :future do
+      deposit_date { Date.tomorrow.to_s }
+    end
+  end
+end

--- a/spec/factories/tradeline.rb
+++ b/spec/factories/tradeline.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :tradeline do
     name { 'Some Credit Card' }
-    amount_cents { 322354 }
+    amount_cents { 3223_54 }
 
     factory :tradeline_with_deposits do
       transient do

--- a/spec/factories/tradeline.rb
+++ b/spec/factories/tradeline.rb
@@ -3,6 +3,21 @@
 FactoryBot.define do
   factory :tradeline do
     name { 'Some Credit Card' }
-    amount { 3223.54 }
+    amount_cents { 322354 }
+
+    factory :tradeline_with_deposits do
+      transient do
+        deposits_cents { [] }
+      end
+
+      deposits do
+        deposits_cents.map do |cents|
+          association(:deposit, tradeline: instance, amount_cents: cents)
+        end
+      end
+      after(:create) do |f, context|
+        f.reload
+      end
+    end
   end
 end

--- a/spec/models/deposit_spec.rb
+++ b/spec/models/deposit_spec.rb
@@ -15,6 +15,23 @@ RSpec.describe Deposit, type: :model do
   end
 
   describe 'validations' do
-    it { should validate_numericality_of(:amount_cents).only_integer.is_greater_than(0) }
+    it do
+      should validate_numericality_of(:amount_cents)
+        .only_integer
+        .is_greater_than(0)
+    end
+
+    it 'rejects amounts exceeding parent Tradeline balance' do
+      deposit = build(:deposit,
+        amount_cents: 300_00,
+        tradeline: build(:tradeline_with_deposits,
+          amount_cents: 10_00,
+          deposits_cents: [5_00],
+        )
+      )
+      expect(deposit.valid?).to be_falsey
+      expect(deposit.errors).to be_present
+      expect(deposit.errors[:amount_cents].join(' ')).to include('Deposit amount exceeds Tradeline balance')
+    end
   end
 end

--- a/spec/models/deposit_spec.rb
+++ b/spec/models/deposit_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Deposit, type: :model do
+  describe 'columns' do
+    it { should have_db_column(:amount_cents).of_type(:integer).with_options(null: false) }
+    it { should have_db_column(:deposit_date).of_type(:date).with_options(null: false) }
+  end
+
+  describe 'indicies' do
+    it { should have_db_index :tradeline_id }
+  end
+
+  describe 'associations' do
+    it { should belong_to(:tradeline).class_name('Tradeline') }
+  end
+
+  describe 'validations' do
+    it { should validate_numericality_of(:amount_cents).only_integer.is_greater_than(0) }
+  end
+end

--- a/spec/models/tradeline_spec.rb
+++ b/spec/models/tradeline_spec.rb
@@ -7,10 +7,33 @@ RSpec.describe Tradeline, type: :model do
 
   describe 'virtual fields' do
     it 'calculates amount from amount_cents' do
-      t = build(:tradeline, amount_cents: 123456)
+      t = build(:tradeline, amount_cents: 1234_56)
 
       expect(t.amount).to eq(1234.56)
     end
-  end
 
+    it 'pulls accurate balance_cents from associated in-memory deposits' do
+      t = build(:tradeline,
+        amount_cents: 1234_56,
+        deposits: {
+          1000_00 => Date.yesterday.to_s,
+          200_00 => Date.today.to_s,
+          56 => Date.tomorrow.to_s, # won't count towards balance!
+        }.map do |cents, day|
+          build(:deposit, tradeline: t, amount_cents: cents, deposit_date: day)
+        end
+      )
+
+      expect(t.balance_cents).to eq(34_56)
+    end
+
+    it 'pulls accurate balance_cents from db deposits' do
+      t = create(:tradeline_with_deposits,
+        amount_cents: 2345_67,
+        deposits_cents: [2000_00, 300_00, 67]
+      )
+
+      expect(t.balance_cents).to eq(45_00)
+    end
+  end
 end

--- a/spec/models/tradeline_spec.rb
+++ b/spec/models/tradeline_spec.rb
@@ -4,4 +4,13 @@ RSpec.describe Tradeline, type: :model do
   describe 'associations' do
     it { should have_many(:deposits).class_name('Deposit') }
   end
+
+  describe 'virtual fields' do
+    it 'calculates amount from amount_cents' do
+      t = build(:tradeline, amount_cents: 123456)
+
+      expect(t.amount).to eq(1234.56)
+    end
+  end
+
 end

--- a/spec/models/tradeline_spec.rb
+++ b/spec/models/tradeline_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Tradeline, type: :model do
+  describe 'associations' do
+    it { should have_many(:deposits).class_name('Deposit') }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,4 +60,12 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,16 @@
 # it.
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'simplecov'
+SimpleCov.start 'rails' do
+  enable_coverage :branch
+end if ENV["COVERAGE"]
+
+require 'factory_bot_rails'
+
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
@@ -91,4 +100,6 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
+  config.filter_run_when_matching :focus
 end


### PR DESCRIPTION
## Summary

Implements additional API functionality to add Deposits to existing Tradelines and view Deposits both independently and associated with a given Tradeline.

Relevant routes:
- `GET /tradelines` (Existing) index of Tradelines in the system. Now includes `deposits` associated with each Tradeline.
- `GET /tradelines/:id` (Existing) individual Tradeline display. Now includes `deposits` associated with the given Tradeline.
- `GET /tradelines/:tradeline_id/deposits` New route listing Deposits associated with `:tradeline_id`. Payload overlaps with `GET /tradelines/:id`.
- `GET /deposits/:id` New individual Deposit display. Does not currently show associated parent Tradeline.
- `POST /tradelines/:tradeline_id/deposits { deposit: { amount_cents: 0, deposit_date: '2024-06-08' } }` New route to submit a Deposit to an existing Tradeline. Validates that the `amount_cents` will not exceed the Tradeline's current `balance_cents`.

## Tasks

Tasks

- [x] Clone repo.
- [x] Create a new `beporter/beyond_finance_deposits_exercise` repo and push as separate remote.
- [x] Start a new branch for exercise.
- [x] Create a migration to generate a `deposits` table. Should have a foreign `tradeline_id` key, integer `amount_cents`, and `deposit_date` timestamp.
- [x] Add an association to the Tradeline model for Deposit.
- [x] Update the finder in Tradelines#index and #show to eager load deposits.
- [x] Expose `balance_cents` in the tradelines json.
- [x] Consider caching this value if it's expensive.
- [x] Also consider appropriate DB indices for quick queries by tradeline_id.
- [x] Virtual field on Tradeline for balance due?
- [x] New DepositsController with #create route with a method like `POST /tradelines/:id/deposits`.
  - [x] 404 if Tradeline ID doesn't exist.
  - [x] 422 if submitted deposit amount is greater than balance due on the Tradeline.
- [x] NOT a 422 if date is in the past? (Specs say deposits are "most likely" a future date but there's no explicit ban on submitting Deposits that are dated in the past.)
- [x] Create a `GET /tradelines/:id/deposits` index endpoint.
- [x] Create a `GET /deposits/:id` show endpoint.

## Open Questions

- Exercise instructions don't mention whether to write tests for new work. I did anyway out of force of habit.
- If a Deposit is submitted for a future date, does it count against the "balance due" for the Tradeline if an api query is made before that date? I implemented this so only "past deposits" count against the balance. 🤷‍♂️ 

## Exercise Comments
- If we were using a full RDBMS, I'd recommend the `strong_migrations` gem to help guard against some potentially dangerous migration operations. (Although even this gem doesn't prevent everything. Requires coordination of RDBMS settings with sysops personnel.)
- Dollar amounts should absolutely NOT be stored as decimals. I corrected this for the existing `Tradeline.amount` field under the assumption this project doesn't have anything like a production environment yet. The alternative, storing as cents, makes all math integer-based and avoids 0.1 style [accuracy issues](https://en.wikipedia.org/wiki/Floating-point_arithmetic#Accuracy_problems).  **Displaying** as decimal dollars should be a presentation thing, not a storage thing.
- From copious negative firsthand experience, I suggest that fields that contain a measurement should typically include the measurement's unit in the column name. For example: `amount` doesn't tell you if this is dollars or yen or _chickens_. `amount_cents` is abandantly clear. Or take `length_mm` vs `length_km`. Units matter; just [ask NASA](http://www.cnn.com/TECH/space/9909/30/mars.metric.02/).
- If this were a real project, I'm a fan of [JSON:API](https://github.com/jsonapi-serializer/jsonapi-serializer) for serialization, not necessarily because it gets things "right" (it's pretty verbose and the nesting can be tricky) but because it outsources a lot of "how should we do X?" answers to the spec so the dev team doesn't have to think about it or debate it. That same "convention over configuration" approach then applies to API _consumer_ developers as well. Developers know the structure to expect from the api, and can reference the spec to understand it. Makes documenting and linting the api **data** considerable more straightforward too.
- I didn't specifically install and configure a linter like rubocop because it felt out-of-scope to isolate corrections to only my own additions. Therefore there are probably some inconsistencies in my coding style that I'd normally allow the linter to catch/correct for me.

## Code Review

The [top level project readme](https://github.com/beporter/beyond_finance_deposits_exercise/blob/main/README.md) contains the instructions for the exercise. Please “grade” this PR as critically as you can using the criteria there. I also welcome all auxiliary feedback: “why no linting?” or “why not use X serializer?” etc. are all most welcome.

## Console Transcript

Sometimes for the sake of examining a coding exercise, it can be illuminating to see not only the code changes, but the commands used to facilitate some of those code changes. This is an incomplete but representative transcript of terminal commands used.

```shell
# Clone the repo.
cd ~/Projects/

mkdir BeyondFinance

cd BeyondFinance/

git clone https://github.com/Beyond-Finance/deposits_exercise.git

cd deposits_exercise/


# Switch the clone's origin to my own copy of the repo (created in the Github.com web UI.)
git remote set-url origin git@github.com:beporter/beyond_finance_deposits_exercise.git

git remote set-url --push origin git@github.com:beporter/beyond_finance_deposits_exercise.git

git remote -vv

git push


# Basic env setup.
rvm install ruby-3.3.0

bundle

rails db:setup


# Start a working branch.
git checkout -b beporter-submission


# Generate a new Deposit model.
rails generate model Deposit tradeline:references amount_cents:integer deposit_date:date

rails db:migrate


# Run after adding some utility/testing gems.
bundle

bundle exec guard init rspec

rails generate annotate:install

rails generate validates_timeliness:install

rails annotate_models


# Convert Tradeline#amount column to cents.
rails generate migration AddAmountCentsToTradelines

rails generate migration RemoveAmountFromTradelines

rails db:migrate


# Create new DepositsController for show.
rails generate controller Deposits show


# Guard tests to run on file change.
guard


# Run tests with coverage.
COVERAGE=true rspec
open coverage/index.html
```